### PR TITLE
80 delete room

### DIFF
--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -34,7 +34,7 @@ router.post("/room", supabaseAuth, async (req: Request, res: Response) => {
       location: location || "Online",
       created_by: req.authUser.id,
       created_at: new Date().toISOString(),
-      password_hash: hashedPassword
+      password_hash: hashedPassword,
     };
 
     const { data: roomResult, error: roomError } = await supabaseClient
@@ -80,12 +80,61 @@ router.get("/", supabaseAuth, async (req: Request, res: Response) => {
       return res.status(500).json({ error: error.message });
     }
 
-    const sanitizedRooms = data.map(room => ({
+    const sanitizedRooms = data.map((room) => ({
       ...room,
       isPrivate: room.password_hash !== null, // true if password exists, dont send hash password to FE
     }));
 
     res.json(sanitizedRooms);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// DELETE /api/rooms/:roomId - Delete a room (owner only)
+router.delete("/:roomId", supabaseAuth, async (req: Request, res: Response) => {
+  try {
+    const { roomId } = req.params;
+    const supabaseClient = req.supabaseClient;
+    const authUser = req.authUser;
+
+    if (!supabaseClient) {
+      return res.status(500).json({ error: "Supabase client not initialized" });
+    }
+    if (!authUser) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    // Only the creator can delete the room
+    const { data: room, error: fetchError } = await supabaseClient
+      .from("rooms")
+      .select("created_by")
+      .eq("id", roomId)
+      .single();
+
+    if (fetchError || !room) {
+      return res.status(404).json({ error: "Room not found" });
+    }
+    if (room.created_by !== authUser.id) {
+      return res
+        .status(403)
+        .json({ error: "Only the room creator can delete this room" });
+    }
+
+    // Dependent rows are handled by the DB: messages/todos/pomos cascade,
+    // and profiles.room is set null on delete.
+    const { error: deleteError } = await supabaseClient
+      .from("rooms")
+      .delete()
+      .eq("id", roomId);
+
+    if (deleteError) {
+      console.error("Supabase error:", deleteError);
+      return res.status(500).json({ error: "Failed to delete room" });
+    }
+
+    res.json({ message: "Room deleted successfully" });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "Internal server error" });
@@ -165,11 +214,11 @@ router.get(
           .json({ error: "Supabase client not initialized" });
       }
 
-    const { data, error } = await supabaseClient
-      .from("todos")
-      .select("*")
-      .eq("room_id", roomId)
-      .maybeSingle();
+      const { data, error } = await supabaseClient
+        .from("todos")
+        .select("*")
+        .eq("room_id", roomId)
+        .maybeSingle();
 
       if (error) {
         console.error("Supabase error:", error);
@@ -294,22 +343,22 @@ router.get(
           .json({ error: "Supabase client not initialized" });
       }
 
-    const { data, error } = await supabaseClient
-      .from("profiles")
-      .select("id, name, character_id")
-      .eq("room", roomId);
+      const { data, error } = await supabaseClient
+        .from("profiles")
+        .select("id, name, character_id")
+        .eq("room", roomId);
 
       if (error) {
         console.error("Supabase error:", error);
         return res.status(500).json({ error: error.message });
       }
 
-    // Map to RoomUser type
-    const users = data.map((u: any) => ({
-      userId: u.id,
-      name: u.name,
-      characterId: u.character_id,
-    }));
+      // Map to RoomUser type
+      const users = data.map((u: any) => ({
+        userId: u.id,
+        name: u.name,
+        characterId: u.character_id,
+      }));
 
       res.json(users);
     } catch (err) {

--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -92,55 +92,6 @@ router.get("/", supabaseAuth, async (req: Request, res: Response) => {
   }
 });
 
-// DELETE /api/rooms/:roomId - Delete a room (owner only)
-router.delete("/:roomId", supabaseAuth, async (req: Request, res: Response) => {
-  try {
-    const { roomId } = req.params;
-    const supabaseClient = req.supabaseClient;
-    const authUser = req.authUser;
-
-    if (!supabaseClient) {
-      return res.status(500).json({ error: "Supabase client not initialized" });
-    }
-    if (!authUser) {
-      return res.status(401).json({ error: "Unauthorized" });
-    }
-
-    // Only the creator can delete the room
-    const { data: room, error: fetchError } = await supabaseClient
-      .from("rooms")
-      .select("created_by")
-      .eq("id", roomId)
-      .single();
-
-    if (fetchError || !room) {
-      return res.status(404).json({ error: "Room not found" });
-    }
-    if (room.created_by !== authUser.id) {
-      return res
-        .status(403)
-        .json({ error: "Only the room creator can delete this room" });
-    }
-
-    // Dependent rows are handled by the DB: messages/todos/pomos cascade,
-    // and profiles.room is set null on delete.
-    const { error: deleteError } = await supabaseClient
-      .from("rooms")
-      .delete()
-      .eq("id", roomId);
-
-    if (deleteError) {
-      console.error("Supabase error:", deleteError);
-      return res.status(500).json({ error: "Failed to delete room" });
-    }
-
-    res.json({ message: "Room deleted successfully" });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
-
 // GET /api/rooms/:roomId/messages - Get chat history for a specific room
 router.get(
   "/:roomId/messages",

--- a/backend/src/sockets/handlers.ts
+++ b/backend/src/sockets/handlers.ts
@@ -100,7 +100,11 @@ async function fetchRoomStateFromSupabase(
           .limit(1)
           .maybeSingle(),
         client.from("todos").select("*").eq("room_id", roomId).maybeSingle(),
-        client.from("rooms").select("created_by, password_hash").eq("id", roomId).single(),
+        client
+          .from("rooms")
+          .select("created_by, password_hash")
+          .eq("id", roomId)
+          .single(),
         client
           .from("rooms")
           .select("background_id")
@@ -120,9 +124,9 @@ async function fetchRoomStateFromSupabase(
       : null;
 
     const todoState = todosResult.data
-      ? { 
-          id: todosResult.data.id, 
-          items: todosResult.data.items || [] // Fallback to prevent null array crashes
+      ? {
+          id: todosResult.data.id,
+          items: todosResult.data.items || [], // Fallback to prevent null array crashes
         }
       : null;
 
@@ -228,8 +232,11 @@ export const roomHandler = (io: Server) => {
     console.log(`User connected: ${socket.id}`);
 
     socket.on("join-room", async ({ roomId, token }) => {
-      console.log("[Handler] join-room received:", { roomId, socketId: socket.id });
-      
+      console.log("[Handler] join-room received:", {
+        roomId,
+        socketId: socket.id,
+      });
+
       const userId = await getUserFromToken(token);
       if (!userId) {
         socket.emit("error", { message: "Unauthorized" });
@@ -245,25 +252,36 @@ export const roomHandler = (io: Server) => {
         .single();
 
       if (profileError) {
-        console.error(`[Handler] DB Error checking profile for user ${userId}:`, profileError);
-        socket.emit("error", { message: "Server timeout verifying access. Please refresh." });
+        console.error(
+          `[Handler] DB Error checking profile for user ${userId}:`,
+          profileError,
+        );
+        socket.emit("error", {
+          message: "Server timeout verifying access. Please refresh.",
+        });
         return;
       }
 
       if (String(profile?.room) !== String(roomId)) {
-        console.log(`[Handler] User ${userId} blocked from socket join (DB mismatch).`);
-        socket.emit("error", { message: "Access Denied. Please join via the directory." });
+        console.log(
+          `[Handler] User ${userId} blocked from socket join (DB mismatch).`,
+        );
+        socket.emit("error", {
+          message: "Access Denied. Please join via the directory.",
+        });
         return;
       }
 
       // Forcibly remove this user from ANY other rooms in memory
       for (const [existingRoomId, existingRoom] of roomStates.entries()) {
         if (existingRoomId !== roomId && existingRoom.users.has(userId)) {
-          console.log(`[Handler] Sweeping ghost user ${userId} from room ${existingRoomId}`);
-          
+          console.log(
+            `[Handler] Sweeping ghost user ${userId} from room ${existingRoomId}`,
+          );
+
           existingRoom.users.delete(userId);
           io.to(existingRoomId).emit("user-left", { userId });
-          
+
           if (existingRoom.users.size === 0) {
             roomStates.delete(existingRoomId);
           }
@@ -274,7 +292,8 @@ export const roomHandler = (io: Server) => {
       let room = roomStates.get(roomId);
 
       if (!room) {
-        const { hostId, pomodoroState, todoState, backgroundId } = await fetchRoomStateFromSupabase(roomId, token);
+        const { hostId, pomodoroState, todoState, backgroundId } =
+          await fetchRoomStateFromSupabase(roomId, token);
         room = {
           users: new Map(),
           hostId,
@@ -316,7 +335,13 @@ export const roomHandler = (io: Server) => {
 
     socket.on(
       "update-character",
-      async ({ roomId, characterId }: { roomId: string; characterId: string }) => {
+      async ({
+        roomId,
+        characterId,
+      }: {
+        roomId: string;
+        characterId: string;
+      }) => {
         const session = socketUsers.get(socket.id);
         if (!session) {
           socket.emit("error", { message: "Session not found" });
@@ -334,9 +359,9 @@ export const roomHandler = (io: Server) => {
 
         user.characterId = characterId;
 
-        io.to(roomId).emit("character-updated", { 
-          userId: session.userId, 
-          characterId 
+        io.to(roomId).emit("character-updated", {
+          userId: session.userId,
+          characterId,
         });
 
         try {
@@ -347,8 +372,13 @@ export const roomHandler = (io: Server) => {
             .eq("id", session.userId);
 
           if (error) {
-            console.error(`Failed to save character for user ${session.userId}:`, error.message);
-            socket.emit("error", { message: "Failed to save character to database" });
+            console.error(
+              `Failed to save character for user ${session.userId}:`,
+              error.message,
+            );
+            socket.emit("error", {
+              message: "Failed to save character to database",
+            });
           }
         } catch (err) {
           console.error("update-character DB exception:", err);
@@ -375,15 +405,64 @@ export const roomHandler = (io: Server) => {
       }
     });
 
+    // Delete room handler (owner only) — kick everyone in the room live
+    socket.on("delete-room", async ({ roomId }) => {
+      const session = socketUsers.get(socket.id);
+      if (!session) {
+        socket.emit("error", { message: "Session not found" });
+        return;
+      }
+
+      const client = createSupabaseClient(session.token);
+
+      // Only the room creator can delete it
+      const { data: room, error: fetchError } = await client
+        .from("rooms")
+        .select("created_by")
+        .eq("id", roomId)
+        .single();
+
+      if (fetchError || !room) {
+        socket.emit("error", { message: "Room not found" });
+        return;
+      }
+      if (room.created_by !== session.userId) {
+        socket.emit("error", {
+          message: "Only the room creator can delete this room",
+        });
+        return;
+      }
+
+      // Dependent rows are handled by the DB: messages/todos/pomos cascade,
+      // and profiles.room is set null on delete.
+      const { error: deleteError } = await client
+        .from("rooms")
+        .delete()
+        .eq("id", roomId);
+
+      if (deleteError) {
+        console.error("Error deleting room:", deleteError);
+        socket.emit("error", { message: "Failed to delete room" });
+        return;
+      }
+
+      // Notify everyone in the room and clear in-memory state
+      io.to(roomId).emit("room-deleted", { roomId });
+      roomStates.delete(roomId);
+      console.log(`[Handler] Room ${roomId} deleted by ${session.userId}`);
+    });
+
     // Add todo handler
     socket.on(
       "add-todo",
       async ({ roomId, item }: { roomId: string; item: TodoItem }) => {
         console.log("[Handler] add-todo received:", { roomId, item });
         const session = socketUsers.get(socket.id);
-        
+
         if (!session || session.roomId !== roomId) {
-          console.log("[Handler] Authorization failed: socket not in socketUsers or roomId mismatch");
+          console.log(
+            "[Handler] Authorization failed: socket not in socketUsers or roomId mismatch",
+          );
           socket.emit("error", { message: "Unauthorized or room mismatch" });
           return;
         }
@@ -411,7 +490,10 @@ export const roomHandler = (io: Server) => {
 
         // Initialize todoState if it doesn't exist in memory by fetching the trigger-created row
         if (!room.todoState) {
-          console.log("[Handler] Fetching trigger-created todoState for room:", roomId);
+          console.log(
+            "[Handler] Fetching trigger-created todoState for room:",
+            roomId,
+          );
           try {
             const client = createSupabaseClient(session.token);
 
@@ -424,7 +506,9 @@ export const roomHandler = (io: Server) => {
 
             if (fetchError || !existingTodo) {
               console.error("add-todo fetch existing failed:", fetchError);
-              socket.emit("error", { message: "Failed to locate room's todo list" });
+              socket.emit("error", {
+                message: "Failed to locate room's todo list",
+              });
               return;
             }
 
@@ -449,7 +533,10 @@ export const roomHandler = (io: Server) => {
               id: data.id,
               items: data.items || [],
             };
-            console.log("[Handler] todoState loaded and updated with ID:", room.todoState.id);
+            console.log(
+              "[Handler] todoState loaded and updated with ID:",
+              room.todoState.id,
+            );
           } catch (err) {
             console.error("add-todo fetch/update exception:", err);
             socket.emit("error", { message: "Internal server error" });
@@ -514,9 +601,11 @@ export const roomHandler = (io: Server) => {
         );
 
         if (!saved) {
-          room.todoState.items = room.todoState.items.concat(
-            { id: todoId, text: "", completed: false }, 
-          );
+          room.todoState.items = room.todoState.items.concat({
+            id: todoId,
+            text: "",
+            completed: false,
+          });
           socket.emit("error", { message: "Failed to remove todo" });
           return;
         }
@@ -592,10 +681,12 @@ export const roomHandler = (io: Server) => {
       io.to(roomId).emit("new-message", { userId, name, message, timestamp });
 
       // Persist in the background
-      saveMessageToSupabase(roomId, userId, message, session.token)
-        .then((saved) => {
-          if (!saved) console.error(`[DB] Failed to persist message from ${userId}`);
-        });
+      saveMessageToSupabase(roomId, userId, message, session.token).then(
+        (saved) => {
+          if (!saved)
+            console.error(`[DB] Failed to persist message from ${userId}`);
+        },
+      );
 
       console.log(`[Handler] Message from ${name} in room ${roomId}:`, message);
     });
@@ -664,7 +755,9 @@ export const roomHandler = (io: Server) => {
         })
         .eq("id", room.pomodoroState.id)
         .then(() => {
-          console.log(`Updated pomo ${room.pomodoroState?.id} status to running`);
+          console.log(
+            `Updated pomo ${room.pomodoroState?.id} status to running`,
+          );
         });
     });
 
@@ -736,7 +829,9 @@ export const roomHandler = (io: Server) => {
         })
         .eq("id", room.pomodoroState.id)
         .then(() => {
-          console.log(`Updated pomo ${room.pomodoroState?.id} status to paused`);
+          console.log(
+            `Updated pomo ${room.pomodoroState?.id} status to paused`,
+          );
         });
     });
 
@@ -898,11 +993,11 @@ export const roomHandler = (io: Server) => {
 
     socket.on("disconnect", async () => {
       const session = socketUsers.get(socket.id);
-      
+
       if (session) {
         const { userId, roomId, token } = session;
         socketUsers.delete(socket.id);
-        
+
         const room = roomStates.get(roomId);
         if (room) {
           room.users.delete(userId);

--- a/frontend/src/app/(auth)/room/[id]/page.tsx
+++ b/frontend/src/app/(auth)/room/[id]/page.tsx
@@ -172,48 +172,13 @@ export default function Room() {
     }
   };
 
-  const handleDeleteRoom = async () => {
-    try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      const token = session?.access_token;
-      const userId = session?.user.id;
-      if (!token || !userId) throw new Error("User not authenticated");
-
-      const resp = await fetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/rooms/${roomId}`,
-        {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
-        },
-      );
-
-      if (!resp.ok) {
-        const errorResp = await resp.json();
-        showFeedback(
-          "Failed to Delete Room",
-          errorResp.error || "Could not delete the room.",
-        );
-        return;
-      }
-
-      // The room is gone; leave the socket room so other clients update.
-      const socket = getSocket();
-      if (socket) {
-        socket.emit("leave-room", { roomId, userId, token });
-      }
-
-      showFeedback("Room Deleted", "The room has been deleted.", "success");
-      setTimeout(() => {
-        router.push("/rooms");
-      }, 1500);
-    } catch (error) {
-      showFeedback(
-        "Error",
-        error instanceof Error ? error.message : "Failed to delete room",
-      );
+  const handleDeleteRoom = () => {
+    const socket = getSocket();
+    if (!socket || !socket.connected) {
+      showFeedback("Error", "Disconnected. Please refresh and try again.");
+      return;
     }
+    socket.emit("delete-room", { roomId });
   };
 
   const confirmDeleteRoom = () => {
@@ -381,6 +346,16 @@ export default function Room() {
           },
         );
 
+        // The owner deleted this room — kick everyone inside.
+        socket.on("room-deleted", () => {
+          showFeedback(
+            "Room Deleted",
+            "This room has been deleted.",
+            "success",
+          );
+          setTimeout(() => router.push("/rooms"), 1500);
+        });
+
         const emitJoin = () => socket.emit("join-room", { roomId, token });
         if (socket.connected) {
           emitJoin();
@@ -410,6 +385,7 @@ export default function Room() {
         socket.off("user-left");
         socket.off("background-updated");
         socket.off("character-updated");
+        socket.off("room-deleted");
         socket.off("error");
         socket.off("connect");
       }

--- a/frontend/src/app/(auth)/room/[id]/page.tsx
+++ b/frontend/src/app/(auth)/room/[id]/page.tsx
@@ -6,7 +6,7 @@ import Loading from "@/components/Loading";
 import PomodoroTimer from "@/components/PomodoroTimer";
 import TodoList from "@/components/TodoList";
 import ChatBox from "@/components/ChatBox";
-import { PencilLine, Check, LogOut } from "lucide-react";
+import { PencilLine, Check, LogOut, Trash2 } from "lucide-react";
 import { useEffect, useState, useRef } from "react";
 import { type Room, type TodoState } from "@/lib/types";
 import { supabase } from "@/supabaseClient";
@@ -22,7 +22,6 @@ import { click2 } from "@/lib/sounds";
 
 const playClick2 = click2("/sounds/singleClicks01.wav");
 
-
 interface RoomStatePayload {
   users: RoomUser[];
   pomodoroState: unknown;
@@ -34,13 +33,17 @@ interface FeedbackState {
   open: boolean;
   title: string;
   description: string;
-  variant: "success" | "error";
+  variant: "success" | "error" | "warning";
+  actionLabel?: string;
+  cancelLabel?: string;
+  onAction?: () => void | Promise<void>;
 }
 
 export default function Room() {
   const [isEditing, setIsEditing] = useState(false);
   const [data, setData] = useState<Room | null>(null);
   const [createdBy, setCreatedBy] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [selectedBg, setSelectedBg] = useState(backgrounds[0]);
   const [showPicker, setShowPicker] = useState(false);
   const [roomUsers, setRoomUsers] = useState<RoomUser[]>([]);
@@ -81,7 +84,10 @@ export default function Room() {
     if (socket.connected) {
       socket.emit("update-character", { roomId, characterId: c.id });
     } else {
-      showFeedback("Error", "Disconnected. Please refresh to change character.");
+      showFeedback(
+        "Error",
+        "Disconnected. Please refresh to change character.",
+      );
     }
   };
 
@@ -89,7 +95,10 @@ export default function Room() {
     try {
       const socket = getSocket();
       if (!socket) {
-        showFeedback("Error", "Socket not initialised. Please refresh the page.");
+        showFeedback(
+          "Error",
+          "Socket not initialised. Please refresh the page.",
+        );
         return;
       }
       if (!socket.connected) {
@@ -147,7 +156,11 @@ export default function Room() {
         return;
       }
 
-      showFeedback("Room Left", "You have successfully left the room.", "success");
+      showFeedback(
+        "Room Left",
+        "You have successfully left the room.",
+        "success",
+      );
       setTimeout(() => {
         router.push("/rooms");
       }, 1500);
@@ -157,6 +170,63 @@ export default function Room() {
         error instanceof Error ? error.message : "Failed to leave room",
       );
     }
+  };
+
+  const handleDeleteRoom = async () => {
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const token = session?.access_token;
+      const userId = session?.user.id;
+      if (!token || !userId) throw new Error("User not authenticated");
+
+      const resp = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/rooms/${roomId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      if (!resp.ok) {
+        const errorResp = await resp.json();
+        showFeedback(
+          "Failed to Delete Room",
+          errorResp.error || "Could not delete the room.",
+        );
+        return;
+      }
+
+      // The room is gone; leave the socket room so other clients update.
+      const socket = getSocket();
+      if (socket) {
+        socket.emit("leave-room", { roomId, userId, token });
+      }
+
+      showFeedback("Room Deleted", "The room has been deleted.", "success");
+      setTimeout(() => {
+        router.push("/rooms");
+      }, 1500);
+    } catch (error) {
+      showFeedback(
+        "Error",
+        error instanceof Error ? error.message : "Failed to delete room",
+      );
+    }
+  };
+
+  const confirmDeleteRoom = () => {
+    setFeedback({
+      open: true,
+      title: "Delete this room?",
+      description:
+        "This room and its chat and todos will be permanently deleted. This cannot be undone.",
+      variant: "warning",
+      actionLabel: "Delete",
+      cancelLabel: "Cancel",
+      onAction: handleDeleteRoom,
+    });
   };
 
   const handleBgChange = async (bg: (typeof backgrounds)[0]) => {
@@ -209,9 +279,12 @@ export default function Room() {
 
   const fetchSavedCharacter = async (token: string) => {
     try {
-      const resp = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/profile`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const resp = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/profile`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
       if (resp.ok) {
         const profile = await resp.json();
         if (profile.character_id) {
@@ -239,6 +312,8 @@ export default function Room() {
         if (isMounted) showFeedback("Error", "User not authenticated");
         return;
       }
+
+      if (isMounted) setCurrentUserId(session?.user.id ?? null);
 
       try {
         await Promise.all([
@@ -279,7 +354,13 @@ export default function Room() {
 
         socket.on(
           "character-updated",
-          ({ userId, characterId }: { userId: string; characterId: string }) => {
+          ({
+            userId,
+            characterId,
+          }: {
+            userId: string;
+            characterId: string;
+          }) => {
             setRoomUsers((prevUsers) =>
               prevUsers.map((user) =>
                 user.userId === userId ? { ...user, characterId } : user,
@@ -292,10 +373,13 @@ export default function Room() {
           setRoomUsers((prev) => prev.filter((u) => u.userId !== userId));
         });
 
-        socket.on("background-updated", ({ backgroundId }: { backgroundId: string }) => {
-          const bg = backgrounds.find((b) => b.id === backgroundId);
-          if (bg) setSelectedBg(bg);
-        });
+        socket.on(
+          "background-updated",
+          ({ backgroundId }: { backgroundId: string }) => {
+            const bg = backgrounds.find((b) => b.id === backgroundId);
+            if (bg) setSelectedBg(bg);
+          },
+        );
 
         const emitJoin = () => socket.emit("join-room", { roomId, token });
         if (socket.connected) {
@@ -397,10 +481,14 @@ export default function Room() {
 
               {/* Author and Room Description */}
               <div className="flex flex-col sm:flex-row w-full gap-2 sm:gap-6 text-(--dark-blue) sm:justify-between sm:items-center">
-                <div className="font-mono text-sm">{data?.description || ""}</div>
+                <div className="font-mono text-sm">
+                  {data?.description || ""}
+                </div>
                 <div className="bg-(--pastel-yellow) border-2 border-(--dark-blue) rounded-xl p-2 text-sm self-start sm:self-auto whitespace-nowrap">
                   Created by:{" "}
-                  <span className="font-semibold">{createdBy || "Unknown"}</span>
+                  <span className="font-semibold">
+                    {createdBy || "Unknown"}
+                  </span>
                 </div>
               </div>
 
@@ -423,7 +511,7 @@ export default function Room() {
                   <button
                     onClick={() => {
                       playClick2();
-                      setShowPicker(!showPicker)
+                      setShowPicker(!showPicker);
                     }}
                     className="bg-(--dark-blue) text-white font-mono text-xs px-4 py-2 rounded-xl hover:opacity-80 transition-opacity"
                   >
@@ -431,26 +519,33 @@ export default function Room() {
                   </button>
 
                   <div
-                    className={`absolute bottom-full left-0 mb-2 z-10 origin-bottom transition-all duration-200 ease-out ${showPicker
-                      ? "opacity-100 scale-100 translate-y-0 pointer-events-auto"
-                      : "opacity-0 scale-95 translate-y-1 pointer-events-none"
+                    className={`absolute bottom-full left-0 mb-2 z-10 origin-bottom transition-all duration-200 ease-out ${
+                      showPicker
+                        ? "opacity-100 scale-100 translate-y-0 pointer-events-auto"
+                        : "opacity-0 scale-95 translate-y-1 pointer-events-none"
                     }`}
                   >
                     <div className="bg-(--dark-blue) border-2 border-white/20 rounded-xl p-3 flex flex-col gap-2">
                       {backgrounds.map((b) => (
-                        <div key={b.id} className="flex flex-col items-center gap-1">
+                        <div
+                          key={b.id}
+                          className="flex flex-col items-center gap-1"
+                        >
                           <Image
                             src={b.src}
                             alt={b.label}
                             width={80}
                             height={56}
                             onClick={() => handleBgChange(b)}
-                            className={`w-16 sm:w-20 h-12 sm:h-14 object-cover rounded-xl cursor-pointer border-2 ${selectedBg.id === b.id
-                              ? "border-white"
-                              : "border-transparent hover:border-white/50"
+                            className={`w-16 sm:w-20 h-12 sm:h-14 object-cover rounded-xl cursor-pointer border-2 ${
+                              selectedBg.id === b.id
+                                ? "border-white"
+                                : "border-transparent hover:border-white/50"
                             }`}
                           />
-                          <span className="text-white font-mono text-xs">{b.label}</span>
+                          <span className="text-white font-mono text-xs">
+                            {b.label}
+                          </span>
                         </div>
                       ))}
                     </div>
@@ -462,7 +557,7 @@ export default function Room() {
                   <button
                     onClick={() => {
                       playClick2();
-                      setShowCharacterPicker(!showCharacterPicker)
+                      setShowCharacterPicker(!showCharacterPicker);
                     }}
                     className="bg-(--dark-blue) text-white font-mono text-xs px-4 py-2 rounded-xl hover:opacity-80 transition-opacity"
                   >
@@ -470,19 +565,24 @@ export default function Room() {
                   </button>
 
                   <div
-                    className={`absolute bottom-full left-0 mb-2 z-10 origin-bottom transition-all duration-200 ease-out ${showCharacterPicker
-                      ? "opacity-100 scale-100 translate-y-0 pointer-events-auto"
-                      : "opacity-0 scale-95 translate-y-1 pointer-events-none"
+                    className={`absolute bottom-full left-0 mb-2 z-10 origin-bottom transition-all duration-200 ease-out ${
+                      showCharacterPicker
+                        ? "opacity-100 scale-100 translate-y-0 pointer-events-auto"
+                        : "opacity-0 scale-95 translate-y-1 pointer-events-none"
                     }`}
                   >
                     <div className="bg-(--dark-blue) border-2 border-white/20 rounded-xl p-3 overflow-y-auto max-h-131 flex flex-col character-picker-scroll">
                       {characters.map((c) => (
-                        <div key={c.id} className="flex flex-col items-center gap-1">
+                        <div
+                          key={c.id}
+                          className="flex flex-col items-center gap-1"
+                        >
                           <div
                             onClick={() => handleCharacterChange(c)}
-                            className={`w-12 sm:w-16 h-16 sm:h-20 rounded cursor-pointer border-2 shrink-0 ${selectedCharacter.id === c.id
-                              ? "border-white"
-                              : "border-transparent"
+                            className={`w-12 sm:w-16 h-16 sm:h-20 rounded cursor-pointer border-2 shrink-0 ${
+                              selectedCharacter.id === c.id
+                                ? "border-white"
+                                : "border-transparent"
                             }`}
                             style={{
                               backgroundImage: `url(${c.src})`,
@@ -498,6 +598,23 @@ export default function Room() {
                     </div>
                   </div>
                 </div>
+
+                {/* Delete room (owner only) */}
+                {currentUserId && data?.createdBy === currentUserId && (
+                  <button
+                    aria-label="Delete Room"
+                    onClick={() => {
+                      playClick2();
+                      confirmDeleteRoom();
+                    }}
+                    className="ml-auto group flex items-center justify-end overflow-hidden bg-transparent text-rose-500/80 border-2 border-rose-300 font-mono text-xs px-3 py-2 rounded-xl hover:bg-rose-600 hover:text-white hover:border-rose-600 transition-colors cursor-pointer"
+                  >
+                    <span className="max-w-0 opacity-0 overflow-hidden whitespace-nowrap transition-all duration-300 ease-out group-hover:max-w-30 group-hover:opacity-100 group-hover:mr-2">
+                      Delete Room
+                    </span>
+                    <Trash2 size={14} className="shrink-0" />
+                  </button>
+                )}
               </div>
             </div>
 
@@ -514,12 +631,20 @@ export default function Room() {
       <FeedbackModal
         open={feedback.open}
         onOpenChange={(open) => {
-          if (!open) setFeedback((prev) => ({ ...prev, open: false, title: "", description: "" }));
+          if (!open)
+            setFeedback((prev) => ({
+              ...prev,
+              open: false,
+              title: "",
+              description: "",
+            }));
         }}
         title={feedback.title}
         description={feedback.description}
         variant={feedback.variant}
-        actionLabel="Close"
+        actionLabel={feedback.actionLabel ?? "Close"}
+        cancelLabel={feedback.cancelLabel}
+        onAction={feedback.onAction}
       />
     </div>
   );

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -53,7 +53,6 @@ export function FeedbackModal({
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent className="border-(--dark-blue)/15 bg-(--light-blue) shadow-[0_24px_80px_rgba(95,123,147,0.25)]">
-
         <AlertDialogHeader className="items-center gap-3 text-center">
           <div
             className={`flex h-12 w-12 items-center justify-center rounded-full ${variantStyles[variant]}`}
@@ -61,7 +60,7 @@ export function FeedbackModal({
             <Icon className="h-6 w-6" />
           </div>
 
-          <AlertDialogTitle className="text-2xl font-black text-[var(--dark-blue)]">
+          <AlertDialogTitle className="text-2xl font-black text-(--dark-blue)">
             {title}
           </AlertDialogTitle>
 
@@ -71,12 +70,11 @@ export function FeedbackModal({
         </AlertDialogHeader>
 
         <AlertDialogFooter className="sm:justify-center gap-3">
-
           {/* Cancel Button */}
           {cancelLabel && (
             <Button
               variant="outline"
-              className="h-10 rounded-full px-6 text-sm font-semibold text-[var(--dark-blue)]"
+              className="h-10 rounded-full px-6 text-sm font-semibold text-(--dark-blue)"
               onClick={() => onOpenChange(false)}
             >
               {cancelLabel}
@@ -86,7 +84,7 @@ export function FeedbackModal({
           {/* Action Button */}
           <AlertDialogAction asChild>
             <Button
-              className="h-10 rounded-full px-6 text-sm font-semibold bg-[var(--dark-blue)] text-white hover:opacity-90"
+              className="h-10 rounded-full px-6 text-sm font-semibold bg-(--dark-blue) text-white hover:opacity-90"
               onClick={async () => {
                 if (onAction) await onAction();
                 onOpenChange(false);
@@ -95,7 +93,6 @@ export function FeedbackModal({
               {actionLabel}
             </Button>
           </AlertDialogAction>
-
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>


### PR DESCRIPTION
Closes #80

https://github.com/user-attachments/assets/1553d86b-2224-4bb5-adf1-1957d5d17777


Let room owners delete their room from the room page. Deletion runs through a new `delete-room` socket event so every user currently in the room is evicted in real time.

**Backend:**
- Add `delete-room` socket handler (owner-only) that deletes the room,
  broadcasts `room-deleted` to the room, and clears in-memory state

**Frontend:**
- Add owner-only "Delete Room" button to the room page picker row,
  with a hover-expand animation and confirmation dialog
- Emit `delete-room` and redirect all members to /rooms on `room-deleted`

**DB changes (applied in Supabase):** 
owner-only DELETE RLS policy on rooms, profiles.room FK set to ON DELETE SET NULL, and ON DELETE CASCADE on messages/todos/pomos.